### PR TITLE
Support for setting server profile on bootstrap

### DIFF
--- a/manifests/bootstrap/zsmanage.pp
+++ b/manifests/bootstrap/zsmanage.pp
@@ -15,13 +15,16 @@ class zendserver::bootstrap::zsmanage inherits zendserver::bootstrap {
       #If license_details are empty then Zend Server will operate in trial mode
       $license = ''
     }
+    if defined('$zendserver::production') {
+      $profile = "-r ${zendserver::production}"
+    }
     #TODO: switch to using the zendserver::sdk once it's more reliable
     #Bootstrap Zend Server using zsmanage
     zendserver::zsmanage { 'bootstrap-single-server':
       command            => 'bootstrap-single-server',
       zskey              => $zendserver::admin_api_key_name,
       zssecret           => $zendserver::admin_api_key_secret,
-      additional_options => "${options} ${license}",
+      additional_options => "${options} ${license} ${profile}",
       notify             => Service['zend-server'],
     }
   }


### PR DESCRIPTION
There does not seem to be any way to set the server profile (development or production).

Added ability to do so by having zsmanage use the value of the `zendserver::production` option; default true, false for a development profile.
